### PR TITLE
Fixes #25 Ship platform-specific generated sundials/*.h headers in unified package

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -24,10 +24,8 @@ jobs:
         include:
           - os: ${{ vars.GHA_DEFAULT_RUNNER_MACOS }}
             rid: osx-arm64
-            native_file: libsundials_cvodes.a
           - os: ${{ vars.GHA_DEFAULT_RUNNER_UBUNTU }}
             rid: linux-x64
-            native_file: libsundials_cvodes.a
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -41,11 +39,15 @@ jobs:
           chmod ugo+x buildNix.sh
           ./buildNix.sh
 
+      # Upload the whole staged native/ tree (static lib + generated
+      # sundials/*.h headers). The headers are CMake-generated and
+      # compiler-specific, so the Windows packer cannot regenerate them — they
+      # have to ride along in the artifact.
       - name: Upload native artifact
         uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.rid }}
-          path: runtimes/${{ matrix.rid }}/native/${{ matrix.native_file }}
+          path: runtimes/${{ matrix.rid }}/native
 
   build-windows-and-pack:
     runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS }}

--- a/CVODES.nuspec
+++ b/CVODES.nuspec
@@ -20,8 +20,18 @@
 
     <file src="_._" target="lib\net10.0" />
 
+    <!-- Cross-platform headers from the source tree. Consumers add
+         packages/CVODES/CVODES/include to their include path. -->
     <file src="src\CVODES\include\**\*.h" target="CVODES\include" />
-    <file src="BuildCVODES_Windows\Release\x64\include\sundials\*.h" target="CVODES\include\sundials" />
+
+    <!-- Platform-specific generated headers (sundials_export.h, sundials_config.h,
+         sundials_fconfig.h). CMake's generate_export_header emits compiler-
+         specific macros (__declspec on MSVC vs __attribute__ on gcc/clang), so
+         each runtime ships its own copy. Consumers add
+         packages/CVODES/runtimes/<rid>/native/include to their include path. -->
+    <file src="runtimes\win-x64\native\include\sundials\*.h"   target="runtimes\win-x64\native\include\sundials" />
+    <file src="runtimes\linux-x64\native\include\sundials\*.h" target="runtimes\linux-x64\native\include\sundials" />
+    <file src="runtimes\osx-arm64\native\include\sundials\*.h" target="runtimes\osx-arm64\native\include\sundials" />
 
     <file src="runtimes\win-x64\native\sundials_cvodes.lib" target="runtimes\win-x64\native" />
     <file src="runtimes\linux-x64\native\libsundials_cvodes.a" target="runtimes\linux-x64\native" />

--- a/buildNix.sh
+++ b/buildNix.sh
@@ -48,3 +48,11 @@ make -C BuildCVODES_${Platform}/Release/${Arch}/
 
 mkdir -p runtimes/${RID}/native
 find ./BuildCVODES_${Platform}/Release/${Arch} -name 'libsundials_cvodes.a' -exec cp {} runtimes/${RID}/native/ \;
+
+# Stage the platform-specific generated sundials/*.h headers (sundials_export.h
+# etc) next to the static lib. These are CMake-generated per-build and contain
+# compiler-specific macros (__declspec on MSVC vs __attribute__ on gcc/clang),
+# so each runtime needs its own copy. The unified CVODES.nuspec sources them
+# from here.
+mkdir -p runtimes/${RID}/native/include/sundials
+cp BuildCVODES_${Platform}/Release/${Arch}/include/sundials/*.h runtimes/${RID}/native/include/sundials/

--- a/build_Windows.bat
+++ b/build_Windows.bat
@@ -50,4 +50,14 @@ rem match — use dir /s /b so we only copy actual matches.
 for /f "delims=" %%F in ('dir /s /b /a-d "BuildCVODES_Windows\Release\x64\sundials_cvodes.lib" 2^>nul') do copy "%%F" runtimes\win-x64\native\
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 
+rem Stage the platform-specific generated sundials/*.h headers
+rem (sundials_export.h etc) next to the static lib. These are CMake-generated
+rem per-build and contain compiler-specific macros (__declspec on MSVC), so
+rem each runtime needs its own copy. The unified CVODES.nuspec sources them
+rem from here.
+mkdir runtimes\win-x64\native\include\sundials
+IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
+copy BuildCVODES_Windows\Release\x64\include\sundials\*.h runtimes\win-x64\native\include\sundials\
+IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
+
 endlocal


### PR DESCRIPTION
## Summary

- Fixes [#25](https://github.com/Open-Systems-Pharmacology/CVODES/issues/25). The unified `CVODES` NuGet package was shipping a single Windows-built copy of the CMake-generated `sundials/*.h` headers, breaking Linux/macOS consumers with `'__declspec' attributes are not enabled` (see e.g. the failing macOS run [25436093415](https://github.com/Open-Systems-Pharmacology/OSPSuite.SimModel.Solver.CVODES/actions/runs/25436093415) on [OSPSuite.SimModel.Solver.CVODES PR #39](https://github.com/Open-Systems-Pharmacology/OSPSuite.SimModel.Solver.CVODES/pull/39)).
- Each platform now stages its own generated `sundials/*.h` next to its static lib at `runtimes/<rid>/native/include/sundials/`, the nix CI artifact carries those headers along, and `CVODES.nuspec` packages three platform-discriminated copies under `runtimes/<rid>/native/include/`.
- Cross-platform source headers stay at `CVODES/include/` as before. Consumers now add **two** include directories (`packages/CVODES/CVODES/include` and `packages/CVODES/runtimes/<rid>/native/include`) — the same two-directory pattern SUNDIALS itself exports when built from source.

## Test plan

- [x] CI green on all three runtime jobs (`build-native-nix` × {linux-x64, osx-arm64} and `build-windows-and-pack`).
- [x] Inspect the published `CVODES.5.8.0.<run>.nupkg` artifact and confirm three distinct copies exist:
  - `runtimes/win-x64/native/include/sundials/sundials_export.h`
  - `runtimes/linux-x64/native/include/sundials/sundials_export.h`
  - `runtimes/osx-arm64/native/include/sundials/sundials_export.h`
  with `__declspec` only in the Windows copy.
- [ ] Bump [OSPSuite.SimModel.Solver.CVODES PR #39](https://github.com/Open-Systems-Pharmacology/OSPSuite.SimModel.Solver.CVODES/pull/39) to the new package version, add `packages/CVODES/runtimes/<rid>/native/include` to the CMake/vcxproj include paths, and confirm Linux/macOS builds pass.